### PR TITLE
Change index's class 'get_type()' return type

### DIFF
--- a/pydbml/classes.py
+++ b/pydbml/classes.py
@@ -857,7 +857,7 @@ class Enum(SQLOjbect):
         self.comment = comment
 
     def get_type(self):
-        return EnumType(self.name, self.items)
+        return self
 
     def __getitem__(self, key) -> EnumItem:
         return self.items[key]


### PR DESCRIPTION
I cant see why not do that. Maybe I'm missing something.
Relevant to issue: https://github.com/Vanderhoof/PyDBML/issues/6