### PR TITLE
Added classes and parser directories to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     author='Daniil Minukhin',
     author_email='ddddsa@gmail.com',
     url='https://github.com/Vanderhoof/PyDBML',
-    packages=['pydbml', 'pydbml.definitions'],
+    packages=['pydbml', 'pydbml.classes', 'pydbml.definitions', 'pydbml.parser'],
     license='MIT',
     platforms='any',
     install_requires=[


### PR DESCRIPTION
The current distribution is broken because pydbml.classes and pydbml.parser are missing from setup.py.