### PR TITLE
Note improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # 1.0.2
 
+- New: "backslash newline" is supported in note text (line continuation)
+- New: notes have reference to their parent. Note.sql now depends on type of parent (for tables and columns it's COMMENT ON clause) 
 - Fix: inline ref schema bug, thanks to @jens-koster
 - Fix: (#16) notes were not idempotent, thanks @jens-koster for reporting
 - Fix: (#15) note objects were not supported in project definition, thanks @jens-koster for reporting
 - Fix: (#20) schema didn't work in table group definition, thanks @mjfii for reporting
+- Fix: quotes in note text broke sql and dbml
 
 # 1.0.1
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,2 @@
 - schema.add and .delete to support multiple arguments (handle errors properly)
-- support escape sequences in multiline strings
 - support 2.4.2 (many to many relationships)

--- a/pydbml/classes/column.py
+++ b/pydbml/classes/column.py
@@ -45,6 +45,15 @@ class Column(SQLObject):
         self.default = default
         self.table: Optional['Table'] = None
 
+    @property
+    def note(self):
+        return self._note
+
+    @note.setter
+    def note(self, val: Note) -> None:
+        self._note = val
+        val.parent = self
+
     def get_refs(self) -> List['Reference']:
         '''
         get all references related to this column (where this col is col1 in)

--- a/pydbml/classes/enum.py
+++ b/pydbml/classes/enum.py
@@ -22,6 +22,15 @@ class EnumItem:
         self.note = Note(note)
         self.comment = comment
 
+    @property
+    def note(self):
+        return self._note
+
+    @note.setter
+    def note(self, val: Note) -> None:
+        self._note = val
+        val.parent = self
+
     def __repr__(self):
         '''
         >>> EnumItem('en-US')

--- a/pydbml/classes/index.py
+++ b/pydbml/classes/index.py
@@ -39,6 +39,15 @@ class Index(SQLObject):
         self.comment = comment
 
     @property
+    def note(self):
+        return self._note
+
+    @note.setter
+    def note(self, val: Note) -> None:
+        self._note = val
+        val.parent = self
+
+    @property
     def subject_names(self):
         '''
         Returns updated list of subject names.

--- a/pydbml/classes/note.py
+++ b/pydbml/classes/note.py
@@ -1,18 +1,20 @@
+import re
 from typing import Any
 
 from .base import SQLObject
-# from pydbml.tools import reformat_note_text
-# from pydbml.tools import remove_indentation
 from pydbml.tools import indent
+from pydbml import classes
 
 
 class Note(SQLObject):
+
     def __init__(self, text: Any):
         self.text: str
         if isinstance(text, Note):
             self.text = text.text
         else:
             self.text = str(text) if text else ''
+        self.parent: Any = None
 
     def __str__(self):
         '''
@@ -33,19 +35,54 @@ class Note(SQLObject):
 
         return f'Note({repr(self.text)})'
 
+    def _prepare_text_for_sql(self) -> str:
+        '''
+        - Process special escape sequence: slash before line break, which means no line break
+        https://www.dbml.org/docs/#multi-line-string
+
+        - replace all single quotes with double quotes
+        '''
+
+        pattern = re.compile(r'\\\n')
+        result = pattern.sub('', self.text)
+
+        result = result.replace("'", '"')
+        return result
+
+    def _prepare_text_for_dbml(self):
+        '''Escape single quotes'''
+        pattern = re.compile(r"('''|')")
+        return pattern.sub(r'\\\1', self.text)
+
+    def generate_comment_on(self, entity: str, name: str) -> str:
+        """Generate a COMMENT ON clause out from this note."""
+        quoted_text = f"'{self._prepare_text_for_sql()}'"
+        note_sql = f'COMMENT ON {entity.upper()} "{name}" IS {quoted_text};'
+        return note_sql
+
     @property
     def sql(self):
+        """
+        For Tables and Columns Note is converted into COMMENT ON clause. All other entities don't
+        have notes generated in their SQL code, but as a fallback their notes are rendered as SQL
+        comments when sql property is called directly.
+        """
         if self.text:
-            return '\n'.join(f'-- {line}' for line in self.text.split('\n'))
+            if isinstance(self.parent, (classes.Table, classes.Column)):
+                return self.generate_comment_on(self.parent.__class__.__name__, self.parent.name)
+            else:
+                text = self._prepare_text_for_sql()
+                return '\n'.join(f'-- {line}' for line in text.split('\n'))
         else:
             return ''
 
     @property
     def dbml(self):
-        if '\n' in self.text:
-            note_text = f"'''\n{self.text}\n'''"
+        text = self._prepare_text_for_dbml()
+        if '\n' in text:
+            note_text = f"'''\n{text}\n'''"
         else:
-            note_text = f"'{self.text}'"
+            note_text = f"'{text}'"
 
         note_text = indent(note_text)
         result = f'Note {{\n{note_text}\n}}'

--- a/pydbml/classes/project.py
+++ b/pydbml/classes/project.py
@@ -28,6 +28,15 @@ class Project:
         return f'<Project {self.name!r}>'
 
     @property
+    def note(self):
+        return self._note
+
+    @note.setter
+    def note(self, val: Note) -> None:
+        self._note = val
+        val.parent = self
+
+    @property
     def dbml(self):
         result = comment_to_dbml(self.comment) if self.comment else ''
         result += f'Project "{self.name}" {{\n'

--- a/pydbml/classes/table.py
+++ b/pydbml/classes/table.py
@@ -53,6 +53,15 @@ class Table(SQLObject):
         self.comment = comment
 
     @property
+    def note(self):
+        return self._note
+
+    @note.setter
+    def note(self, val: Note) -> None:
+        self._note = val
+        val.parent = self
+
+    @property
     def full_name(self) -> str:
         return f'{self.schema}.{self.name}'
 
@@ -199,9 +208,7 @@ class Table(SQLObject):
         result += '\n'.join(components)
 
         if self.note:
-            quoted_note = f"'{self.note.text}'"
-            note_sql = f'COMMENT ON TABLE "{self.name}" IS {quoted_note};'
-            result += f'\n\n{note_sql}'
+            result += f'\n\n{self.note.sql}'
 
         for col in self.columns:
             if col.note:

--- a/test/test_classes/test_column.py
+++ b/test/test_classes/test_column.py
@@ -39,7 +39,7 @@ class TestColumn(TestCase):
         self.assertEqual(col.pk, pk)
         self.assertEqual(col.autoinc, autoinc)
         self.assertEqual(col.default, default)
-        self.assertEqual(col.note, note)
+        self.assertEqual(col.note.text, note.text)
         self.assertEqual(col.comment, comment)
 
     def test_database_set(self) -> None:
@@ -289,3 +289,9 @@ multiline''']"""
         self.assertEqual(c2.dbml, expected)
         expected = '"client_id" integer'
         self.assertEqual(c1.dbml, expected)
+
+    def test_note_property(self):
+        note1 = Note('column note')
+        c1 = Column(name='client_id', type='integer')
+        c1.note = note1
+        self.assertIs(c1.note.parent, c1)

--- a/test/test_classes/test_enum.py
+++ b/test/test_classes/test_enum.py
@@ -1,5 +1,6 @@
 from pydbml.classes import Enum
 from pydbml.classes import EnumItem
+from pydbml.classes import Note
 from unittest import TestCase
 
 
@@ -20,6 +21,12 @@ class TestEnumItem(TestCase):
 '''// EnumItem comment
 "en-US" [note: 'preferred']'''
         self.assertEqual(ei.dbml, expected)
+
+    def test_note_property(self):
+        note1 = Note('enum item note')
+        ei = EnumItem('en-US', note='preferred', comment='EnumItem comment')
+        ei.note = note1
+        self.assertIs(ei.note.parent, ei)
 
 
 class TestEnum(TestCase):

--- a/test/test_classes/test_index.py
+++ b/test/test_classes/test_index.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from pydbml.classes import Column
 from pydbml.classes import Expression
 from pydbml.classes import Index
+from pydbml.classes import Note
 from pydbml.classes import Table
 from pydbml.exceptions import ColumnNotFoundError
 
@@ -128,3 +129,11 @@ CREATE INDEX ON "products" ("id");'''
 '''// Comment on the index
 (id, `getdate()`) [name: 'Dated id', pk, unique, type: hash, note: 'Note on the column']'''
         self.assertEqual(i.dbml, expected)
+
+    def test_note_property(self):
+        note1 = Note('column note')
+        t = Table('products')
+        c = Column('id', 'integer')
+        i = Index(subjects=[c])
+        i.note = note1
+        self.assertIs(i.note.parent, i)

--- a/test/test_classes/test_note.py
+++ b/test/test_classes/test_note.py
@@ -1,4 +1,7 @@
 from pydbml.classes import Note
+from pydbml.classes import Table
+from pydbml.classes import Index
+from pydbml.classes import Column
 from unittest import TestCase
 
 
@@ -36,7 +39,7 @@ class TestNote(TestCase):
 }"""
         self.assertEqual(note.dbml, expected)
 
-    def test_sql(self) -> None:
+    def test_sql_general(self) -> None:
         note1 = Note(None)
         self.assertEqual(note1.sql, '')
         note2 = Note('One line of note text')
@@ -47,3 +50,55 @@ class TestNote(TestCase):
 -- will
 -- be the minimum number of leading spaces among all lines. The parser wont automatically remove the number of indentation spaces in the final output."""
         self.assertEqual(note3.sql, expected)
+
+    def test_sql_table(self) -> None:
+        table = Table(name="test")
+        note1 = Note(None)
+        table.note = note1
+        self.assertEqual(note1.sql, '')
+        note2 = Note('One line of note text')
+        table.note = note2
+        self.assertEqual(note2.sql, 'COMMENT ON TABLE "test" IS \'One line of note text\';')
+
+    def test_sql_column(self) -> None:
+        column = Column(name="test", type="int")
+        note1 = Note(None)
+        column.note = note1
+        self.assertEqual(note1.sql, '')
+        note2 = Note('One line of note text')
+        column.note = note2
+        self.assertEqual(note2.sql, 'COMMENT ON COLUMN "test" IS \'One line of note text\';')
+
+    def test_sql_index(self) -> None:
+        t = Table('products')
+        t.add_column(Column('id', 'integer'))
+        index = Index(subjects=[t.columns[0]])
+
+        note1 = Note(None)
+        index.note = note1
+        self.assertEqual(note1.sql, '')
+        note2 = Note('One line of note text')
+        index.note = note2
+        self.assertEqual(note2.sql, '-- One line of note text')
+
+    def test_prepare_text_for_sql(self):
+        line_escape = 'This text \\\nis not split \\\ninto lines'
+        quotes = "'asd' There's ''' asda ''''  asd ''''' asdsa ''"
+
+        note = Note(line_escape)
+        expected = 'This text is not split into lines'
+        self.assertEqual(note._prepare_text_for_sql(), expected)
+
+        note = Note(quotes)
+        expected = '"asd" There"s """ asda """"  asd """"" asdsa ""'
+        self.assertEqual(note._prepare_text_for_sql(), expected)
+
+    def test_prepare_text_for_dbml(self):
+        quotes = "'asd' There's ''' asda ''''  asd ''''' asdsa ''"
+        expected = "\\'asd\\' There\\'s \\''' asda \\'''\\'  asd \\'''\\'\\' asdsa \\'\\'"
+        note = Note(quotes)
+        self.assertEqual(note._prepare_text_for_dbml(), expected)
+
+    def test_escaped_newline_sql(self) -> None:
+        note = Note('One line of note text \\\nstill one line')
+        self.assertEqual(note.sql, '-- One line of note text still one line')

--- a/test/test_classes/test_project.py
+++ b/test/test_classes/test_project.py
@@ -1,4 +1,5 @@
 from pydbml.classes import Project
+from pydbml.classes import Note
 
 from unittest import TestCase
 
@@ -47,3 +48,9 @@ Project "myproject" {
     a: 'b'
 }'''
         self.assertEqual(p.dbml, expected)
+
+    def test_note_property(self):
+        note1 = Note('column note')
+        p = Project('myproject')
+        p.note = note1
+        self.assertIs(p.note.parent, p)

--- a/test/test_classes/test_table.py
+++ b/test/test_classes/test_table.py
@@ -464,3 +464,9 @@ Table "products" as "pd" {
     }
 }"""
         self.assertEqual(t.dbml, expected)
+
+    def test_note_property(self):
+        note1 = Note('table note')
+        t = Table(name='test')
+        t.note = note1
+        self.assertIs(t.note.parent, t)


### PR DESCRIPTION
- Add backref to note parent in `parent` property.
- Support escape newline in note text
- Escape quotes in sql and dbml for notes
- Note.sql now depends on the type of parent: for columns and tables it's COMMENT ON clause; for rest - `-- sql comment`.