### PR TITLE
Allow to pass database during table creation

### DIFF
--- a/pydbml/classes/table.py
+++ b/pydbml/classes/table.py
@@ -33,13 +33,14 @@ class Table(SQLObject):
                  name: str,
                  schema: str = 'public',
                  alias: Optional[str] = None,
+                 database: Optional[Database] = None
                  columns: Optional[Iterable[Column]] = None,
                  indexes: Optional[Iterable[Index]] = None,
                  note: Optional[Union['Note', str]] = None,
                  header_color: Optional[str] = None,
                  comment: Optional[str] = None,
                  abstract: bool = False):
-        self.database: Optional[Database] = None
+        self.database: database
         self.name = name
         self.schema = schema
         self.columns: List[Column] = []


### PR DESCRIPTION
The `database` param was previously renamed `schema` [1] and now we have no way to set this attribute, however when playing with reference I got this error:

```
pydbml.exceptions.UnknownDatabaseError: Database for the table is not
set
```

This exception is raised when we try to get table's refs [2], so I think we need a way to set the database object of a table.

These changes aims to allow that.

[1] https://github.com/Vanderhoof/PyDBML/commit/0b1e71f70d2b92871d270e6d7b8f151458e9b63f
[2] https://github.com/Vanderhoof/PyDBML/blob/1aeae9af21fcfad57698fa15337b0fc288b00877/pydbml/classes/table.py#L118