### PR TITLE
Fix missing headercolor setting in Table dbml generation

### DIFF
--- a/pydbml/classes/table.py
+++ b/pydbml/classes/table.py
@@ -245,6 +245,8 @@ class Table(SQLObject):
         result += f'Table {name} '
         if self.alias:
             result += f'as "{self.alias}" '
+        if self.header_color:
+            result += f'[headercolor: {self.header_color}] '
         result += '{\n'
         columns_str = '\n'.join(c.dbml for c in self.columns)
         result += indent(columns_str) + '\n'

--- a/test/test_classes/test_table.py
+++ b/test/test_classes/test_table.py
@@ -422,6 +422,24 @@ CREATE TABLE "products" (
 }'''
         self.assertEqual(t.dbml, expected)
 
+    def test_header_color_dbml(self):
+        t = Table('products')
+        t.header_color = '#C84432'
+        c1 = Column('id', 'integer')
+        c2 = Column('name', 'varchar2')
+        t.add_column(c1)
+        t.add_column(c2)
+        s = Database()
+        s.add(t)
+
+        expected = \
+'''Table "products" [headercolor: #C84432] {
+    "id" integer
+    "name" varchar2
+}'''
+        self.assertEqual(t.dbml, expected)
+
+
     def test_schema_dbml(self):
         t = Table('products', schema="myschema")
         c1 = Column('id', 'integer')


### PR DESCRIPTION
During my experimentations with this module, I noticed the `dbml` property for the `Table` class was missing the headercolor setting when set.

This PR contains my proposed fix and the associated unit test.

With the following code 
```python
t = Table('products')
t.header_color = '#C84432'
c1 = Column('id', 'integer')
c2 = Column('name', 'varchar2')
t.add_column(c1)
t.add_column(c2)
s = Database()
s.add(t)
```

Without this fix, `t.dbml` returns:
```
Table "products" {
    "id" integer
    "name" varchar2
}
```

With this fix, `t.dbml`returns:
```
Table "products" [headercolor: #C84432] {
    "id" integer
    "name" varchar2
}
```

Cheers