### PR TITLE
Fix bug in DBML column default rendering with single quotes

### DIFF
--- a/pydbml/renderer/dbml/default/column.py
+++ b/pydbml/renderer/dbml/default/column.py
@@ -2,7 +2,7 @@ from typing import Union
 
 from pydbml.classes import Column, Enum, Expression
 from pydbml.renderer.dbml.default.renderer import DefaultDBMLRenderer
-from pydbml.renderer.dbml.default.utils import comment_to_dbml, note_option_to_dbml, quote_string
+from pydbml.renderer.dbml.default.utils import comment_to_dbml, note_option_to_dbml, quote_string, prepare_text_for_dbml
 from pydbml.renderer.sql.default.utils import get_full_name_for_sql
 
 
@@ -11,7 +11,7 @@ def default_to_str(val: Union[Expression, str, int, float]) -> str:
         if val.lower() in ('null', 'true', 'false'):
             return val.lower()
         else:
-            return f"'{val}'"
+            return f"'{prepare_text_for_dbml(val)}'"
     elif isinstance(val, Expression):
         return val.dbml
     else:  # int or float or bool

--- a/test/test_renderer/test_dbml/test_column.py
+++ b/test/test_renderer/test_dbml/test_column.py
@@ -21,6 +21,7 @@ from pydbml.renderer.dbml.default.column import (
         (True, "True"),
         ("False", "false"),
         ("null", "null"),
+        ("b'0'", "'b\\'0\\''"),
     ],
 )
 def test_default_to_str(input: Any, expected: str) -> None:


### PR DESCRIPTION
This PR fixes a bug in the DBML renderer where column default values containing single quotes (`'`) were rendered in a syntax-breaking format.

### Issue:
When rendering column defaults with single quotes, the output would generate invalid DBML syntax. For example:
```dbml
col1 varchar [default: 'b'0'']  // syntax error!
```

### Fix
The default_to_str function now uses the prepare_text_for_dbml utility to ensure that single quotes are properly escaped, resulting in valid DBML syntax. For example:
```dbml
col1 varchar [default: 'b\'0\'']  // ok
```

### Changes

- Bug fix: Integrated prepare_text_for_dbml into the default_to_str function for proper escaping of single quotes and other special characters in column default values.
- Test updates: Added a new test case to validate this fix using a binary string example (b'0').
