### PR TITLE
feat(indexes): support all Postgresql index types

### DIFF
--- a/pydbml/definitions/index.py
+++ b/pydbml/definitions/index.py
@@ -15,7 +15,12 @@ from pydbml.parser.blueprints import IndexBlueprint
 pp.ParserElement.set_default_whitespace_chars(' \t\r')
 
 index_type = pp.CaselessLiteral("type:").suppress() + _ - (
-    pp.CaselessLiteral("btree")('type') | pp.CaselessLiteral("hash")('type')
+    pp.CaselessLiteral("brin")('type') |
+    pp.CaselessLiteral("btree")('type') |
+    pp.CaselessLiteral("gin")('type') |
+    pp.CaselessLiteral("gist")('type') |
+    pp.CaselessLiteral("hash")('type') |
+    pp.CaselessLiteral("spgist")('type')
 )
 index_setting = _ + (
     unique('unique')

--- a/pydbml/parser/blueprints.py
+++ b/pydbml/parser/blueprints.py
@@ -166,7 +166,17 @@ class IndexBlueprint(Blueprint):
     subject_names: List[Union[str, ExpressionBlueprint]]
     name: Optional[str] = None
     unique: bool = False
-    type: Optional[Literal['hash', 'btree']] = None
+    type: Optional[
+        Literal[
+            # https://www.postgresql.org/docs/current/indexes-types.html
+            "brin",
+            "btree",
+            "gin",
+            "gist",
+            "hash",
+            "spgist",
+        ]
+    ] = None
     pk: bool = False
     note: Optional[NoteBlueprint] = None
     comment: Optional[str] = None

--- a/test/test_definitions/test_index.py
+++ b/test/test_definitions/test_index.py
@@ -20,12 +20,16 @@ ParserElement.set_default_whitespace_chars(' \t\r')
 
 class TestIndexType(TestCase):
     def test_correct(self) -> None:
-        val = 'Type: BTREE'
-        res = index_type.parse_string(val, parseAll=True)
-        self.assertEqual(res['type'], 'btree')
-        val2 = 'type:\nhash'
-        res2 = index_type.parse_string(val2, parseAll=True)
-        self.assertEqual(res2['type'], 'hash')
+        for val, expected in [
+            ("Type: BTREE", "btree"),
+            ("type: hash", "hash"),
+            ("type: gist", "gist"),
+            ("TYPE:SPGiST", "spgist"),
+            ("type: GIN", "gin"),
+            ("Type:\tbRiN", "brin"),
+        ]:
+            res = index_type.parse_string(val, parseAll=True)
+            self.assertEqual(res["type"], expected)
 
     def test_incorrect(self) -> None:
         val = 'type: wrong'


### PR DESCRIPTION
**Context**: We can have other index types than `hash`, `btree`

**Solution**: Implement all of them for Postsgreql as described in https://www.postgresql.org/docs/current/indexes-types.html

Note that `SP-GiST` is named `spgist`in indexes of Postgresql, (similar to B-Tree -> btree)

Ref: https://github.com/Vanderhoof/PyDBML/issues/56

