### PR TITLE
Feat/defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,12 @@ CREATE TYPE "orders_status" AS ENUM (
   'created',
   'running',
   'done',
-  'failure',
+  'failure'
 );
 <BLANKLINE>
 CREATE TYPE "product status" AS ENUM (
   'Out of Stock',
-  'In Stock',
+  'In Stock'
 );
 <BLANKLINE>
 CREATE TABLE "orders" (

--- a/pydbml/renderer/dbml/default/column.py
+++ b/pydbml/renderer/dbml/default/column.py
@@ -24,7 +24,7 @@ def render_options(model: Column) -> str:
         options.append('pk')
     if model.autoinc:
         options.append('increment')
-    if model.default:
+    if model.default is not None:
         options.append(f'default: {default_to_str(model.default)}')
     if model.unique:
         options.append('unique')

--- a/pydbml/renderer/sql/default/column.py
+++ b/pydbml/renderer/sql/default/column.py
@@ -1,8 +1,18 @@
+from typing import Union
+
 from pydbml.classes import Column, Enum, Expression
 from pydbml.renderer.sql.default.renderer import DefaultSQLRenderer
 from .utils import comment_to_sql
 from .enum import get_full_name_for_sql as get_full_name_for_sql_enum
 
+def default_to_str(val: Union[Expression, str, int, float, bool]) -> str:
+    if isinstance(val, Expression):
+        return DefaultSQLRenderer.render(val)
+    elif isinstance(val, str):
+        val = val.replace("'", "''")
+        return f"'{val}'"
+    else:
+        return str(val)
 
 @DefaultSQLRenderer.renderer_for(Column)
 def render_column(model: Column) -> str:
@@ -28,11 +38,7 @@ def render_column(model: Column) -> str:
     if model.not_null:
         components.append('NOT NULL')
     if model.default is not None:
-        if isinstance(model.default, Expression):
-            default = DefaultSQLRenderer.render(model.default)
-        else:
-            default = model.default  # type: ignore
-        components.append(f'DEFAULT {default}')
+        components.append(f'DEFAULT {default_to_str(model.default)}')
 
     result = comment_to_sql(model.comment) if model.comment else ''
     result += ' '.join(components)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -65,6 +65,28 @@ def complex_column_with_table(db: Database, table1: Table, complex_column: Colum
     db.add(table1)
     return complex_column
 
+@pytest.fixture
+def string_column() -> Column:
+    return Column(
+        name='name',
+        type='varchar(255)',
+        pk=False,
+        autoinc=False,
+        unique=True,
+        not_null=True,
+        default='value\'s',
+        comment='This is a defaulted string column',
+        note=Note('This is a note for the column'),
+        properties={'foo': 'bar', 'baz': "qux\nqux"}
+    )
+
+
+@pytest.fixture
+def string_column_with_table(db: Database, table1: Table, string_column: Column) -> Column:
+    table1.add_column(string_column)
+    db.add(table1)
+    return string_column
+
 
 @pytest.fixture
 def table1() -> Table:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -87,6 +87,28 @@ def string_column_with_table(db: Database, table1: Table, string_column: Column)
     db.add(table1)
     return string_column
 
+@pytest.fixture
+def boolean_column() -> Column:
+    return Column(
+        name='enabled',
+        type='boolean',
+        pk=False,
+        autoinc=False,
+        unique=False,
+        not_null=True,
+        default=False,
+        comment='This is a defaulted boolean column',
+        note=Note('This is a note for the column'),
+        properties={'foo': 'bar', 'baz': "qux\nqux"}
+    )
+
+
+@pytest.fixture
+def boolean_column_with_table(db: Database, table1: Table, boolean_column: Column) -> Column:
+    table1.add_column(boolean_column)
+    db.add(table1)
+    return boolean_column
+
 
 @pytest.fixture
 def table1() -> Table:

--- a/test/test_data/integration1.dbml
+++ b/test/test_data/integration1.dbml
@@ -12,7 +12,7 @@ Enum "level" {
 Table "Employees" as "emp" {
     "id" integer [pk, increment]
     "name" varchar [note: 'Full employee name']
-    "age" number
+    "age" number [default: 0]
     "level" level
     "favorite_book_id" integer
 }

--- a/test/test_renderer/test_dbml/test_column.py
+++ b/test/test_renderer/test_dbml/test_column.py
@@ -137,3 +137,13 @@ class TestRenderColumn:
             "a note for the column']"
         )
         assert render_column(complex_column_with_table) == expected
+
+    @staticmethod
+    def test_string(string_column_with_table: Column) -> None:
+        expected = (
+            "// This is a defaulted string column\n"
+            '"name" varchar(255) [default: \'value\\\'s\', unique, not null, note: \'This is '
+            "a note for the column']"
+        )
+        assert render_column(string_column_with_table) == expected
+

--- a/test/test_renderer/test_dbml/test_column.py
+++ b/test/test_renderer/test_dbml/test_column.py
@@ -133,7 +133,7 @@ class TestRenderColumn:
     def test_complex(complex_column_with_table: Column) -> None:
         expected = (
             "// This is a counter column\n"
-            '"counter" "product status" [pk, increment, unique, not null, note: \'This is '
+            '"counter" "product status" [pk, increment, default: 0, unique, not null, note: \'This is '
             "a note for the column']"
         )
         assert render_column(complex_column_with_table) == expected
@@ -147,3 +147,11 @@ class TestRenderColumn:
         )
         assert render_column(string_column_with_table) == expected
 
+    @staticmethod
+    def test_boolean(boolean_column_with_table: Column) -> None:
+        expected = (
+            "// This is a defaulted boolean column\n"
+            '"enabled" boolean [default: False, not null, note: \'This is '
+            "a note for the column']"
+        )
+        assert render_column(boolean_column_with_table) == expected

--- a/test/test_renderer/test_sql/test_default/test_column.py
+++ b/test/test_renderer/test_sql/test_default/test_column.py
@@ -17,3 +17,12 @@ class TestRenderColumn:
             "0"
         )
         assert render_column(complex_column) == expected
+
+    @staticmethod
+    def test_string(string_column: Column) -> None:
+        expected = (
+            "-- This is a defaulted string column\n"
+            '"name" varchar(255) UNIQUE NOT NULL DEFAULT '
+            "'value''s'"
+        )
+        assert render_column(string_column) == expected

--- a/test/test_renderer/test_sql/test_default/test_column.py
+++ b/test/test_renderer/test_sql/test_default/test_column.py
@@ -26,3 +26,12 @@ class TestRenderColumn:
             "'value''s'"
         )
         assert render_column(string_column) == expected
+
+    @staticmethod
+    def test_string(boolean_column: Column) -> None:
+        expected = (
+            "-- This is a defaulted boolean column\n"
+            '"enabled" boolean NOT NULL DEFAULT '
+            "False"
+        )
+        assert render_column(boolean_column) == expected


### PR DESCRIPTION
This fixes issues with 'rendering' defaults:

a) sql renderer does not properly quote default string values
b) dbml rendered does not output a default for 'falsey' default values (e.g. default: 0 and default: false)

It also fixes the README.md failure (there was an extra trailing `,`)

This fixes https://github.com/Vanderhoof/PyDBML/issues/65 and https://github.com/Vanderhoof/PyDBML/issues/64